### PR TITLE
Update Orbit dependencies to 0.17-0.beta.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@orbit/jsonapi": "^0.17.0-beta.14",
-    "@orbit/records": "^0.17.0-beta.14",
+    "@orbit/jsonapi": "0.17.0-beta.25",
+    "@orbit/records": "0.17.0-beta.25",
     "koa-bodyparser": "^4.3.0",
     "koa-router": "^10.0.0",
     "qs": "^6.9.6"
   },
   "devDependencies": {
-    "@orbit/memory": "^0.17.0-beta.14",
+    "@orbit/memory": "0.17.0-beta.25",
     "@types/koa": "^2.11.3",
     "@types/koa-bodyparser": "^4.3.0",
     "@types/koa-router": "^7.4.0",
@@ -28,7 +28,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "koa": "^2.11.0",
     "node-fetch": "^2.6.1",
-    "orbit-sql": "^0.4.2",
+    "orbit-sql": "https://github.com/backspace/orbit-sql.git#orbit-0.17.0-beta.25-no-legacy-test",
     "prettier": "^2.0.5",
     "qunit": "^2.10.0",
     "release-it": "^14.4.1",

--- a/src/deserialize-params.ts
+++ b/src/deserialize-params.ts
@@ -1,13 +1,13 @@
-import { SortQBParam, FilterQBParam, RecordSchema } from '@orbit/records';
+import { SortParam, FilterParam, RecordSchema } from '@orbit/records';
 import { JSONAPIResourceFieldSerializer } from '@orbit/jsonapi';
 
-export function deserializeFilterQBParams(
+export function deserializeFilterParams(
   schema: RecordSchema,
   serializer: JSONAPIResourceFieldSerializer,
   type: string,
   filter: Record<string, string>
-): FilterQBParam[] {
-  const params: FilterQBParam[] = [];
+): FilterParam[] {
+  const params: FilterParam[] = [];
   for (const property in filter) {
     const attribute = serializer.deserialize(property, { type }) as string;
     if (schema.hasAttribute(type, attribute)) {
@@ -21,13 +21,13 @@ export function deserializeFilterQBParams(
   return params;
 }
 
-export function deserializeSortQBParams(
+export function deserializeSortParams(
   schema: RecordSchema,
   serializer: JSONAPIResourceFieldSerializer,
   type: string,
   sort: string
-): SortQBParam[] {
-  const params: SortQBParam[] = [];
+): SortParam[] {
+  const params: SortParam[] = [];
   for (const property of sort.split(',')) {
     const desc = property.startsWith('-');
     const attribute = serializer.deserialize(

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,8 @@ import bodyParser from 'koa-bodyparser';
 import qs from 'qs';
 
 import {
-  deserializeFilterQBParams,
-  deserializeSortQBParams,
+  deserializeFilterParams,
+  deserializeSortParams,
 } from './deserialize-params';
 import { serializeError } from './serialize-error';
 import { Serializer } from './serializer';
@@ -94,7 +94,7 @@ export default function createJSONAPIRouter(settings: ServerSettings): Router {
       const term = source.queryBuilder.findRecords(type);
       if (filter) {
         term.filter(
-          ...deserializeFilterQBParams(
+          ...deserializeFilterParams(
             source.schema,
             serializer.resourceFieldParamSerializer(),
             type,
@@ -104,7 +104,7 @@ export default function createJSONAPIRouter(settings: ServerSettings): Router {
       }
       if (sort) {
         term.sort(
-          ...deserializeSortQBParams(
+          ...deserializeSortParams(
             schema,
             serializer.resourceFieldParamSerializer(),
             type,
@@ -254,7 +254,7 @@ export default function createJSONAPIRouter(settings: ServerSettings): Router {
               );
               if (filter) {
                 term.filter(
-                  ...deserializeFilterQBParams(
+                  ...deserializeFilterParams(
                     source.schema,
                     serializer.resourceFieldParamSerializer(),
                     relationshipType as string,
@@ -264,7 +264,7 @@ export default function createJSONAPIRouter(settings: ServerSettings): Router {
               }
               if (sort) {
                 term.sort(
-                  ...deserializeSortQBParams(
+                  ...deserializeSortParams(
                     schema,
                     serializer.resourceFieldParamSerializer(),
                     relationshipType as string,

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -12,10 +12,10 @@ import {
   ResourceDocument,
 } from '@orbit/jsonapi';
 import {
+  Serializer as OrbitSerializer,
   SerializerForFn,
   SerializerClassForFn,
   SerializerSettingsForFn,
-  UnknownSerializer,
 } from '@orbit/serializers';
 
 export interface SerializerSettings {
@@ -70,7 +70,7 @@ export class Serializer {
   serializeResourceTypePath(type: string): string {
     const serializer = this.#serializerFor(
       JSONAPISerializers.ResourceTypePath
-    ) as UnknownSerializer;
+    ) as OrbitSerializer;
     return serializer.serialize(type) as string;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,78 +173,86 @@
   dependencies:
     "@octokit/openapi-types" "^5.1.0"
 
-"@orbit/core@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.17.0-beta.14.tgz#268308db98f39e3a4d29ba3948eb003cc25ef405"
-  integrity sha512-W8fvwPqjxJhSXMy2iJkjBaDGEyAO5aPoWTcSAx/WxhHEYFu45BcGpBij0j8OCryKJgSbSpBn5dfP087DZQu9QQ==
+"@orbit/core@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.17.0-beta.25.tgz#a166531146ba275c32109022cf6903e3f2dc06bf"
+  integrity sha512-7g26BNqbFipTUjDCIXGkBAVMI3nYihADezS0FA0vsNMMpAPsX8mgEYJYpPaXq6c9C8VUKaz0H700IRqAvP1ZmQ==
   dependencies:
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/data@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/data/-/data-0.17.0-beta.14.tgz#910de6aac532f7c50352627f4bddd9837e1a718f"
-  integrity sha512-sTz45N7fjayrjoE4IBhEubCWhQlW/X6av0+NaYQu9JJgWLeFGb5RO1COV3wgkglIxxQZY5aZEnS75UxCDe9PaA==
+"@orbit/data@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/data/-/data-0.17.0-beta.25.tgz#8513b48fa587a4d9a7751685deb348f87bab107b"
+  integrity sha512-eDzZGSn2ocUIuR8N2LTzEgBnVQ1MlHiB8/ZpFoCyL8Acy8ALSAaOx5J5gylDooiSA/+100XtOHhquDgINKFv2g==
   dependencies:
-    "@orbit/core" "^0.17.0-beta.14"
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/core" "^0.17.0-beta.25"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/immutable@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/immutable/-/immutable-0.17.0-beta.14.tgz#092f85409b82bafda84eaa2280478805ba904ab6"
-  integrity sha512-8RAXijo9emE4+3S6n8BT8lsQFnTE8O+NlpnBp9TbMjKeEkZCv3lQNgN+M7iJrYfTMRnhqKPevl2EFyAdqPbsOg==
+"@orbit/immutable@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/immutable/-/immutable-0.17.0-beta.25.tgz#f909eaf797b8888ff712ec744e3d4cd147eb65b2"
+  integrity sha512-GSUakoJQXtgz+P1QYgJXZ0yUSMwUr8da14nBJNWbNGkuRU1hQ5Me08BLqynKX1C3jxXT0l+V2/auP0B8YLs62A==
 
-"@orbit/jsonapi@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/jsonapi/-/jsonapi-0.17.0-beta.14.tgz#60a4db4b8281a8c842fb5c8f2f1831c1bc4cf284"
-  integrity sha512-+M4nROrbUL+UVtRLTIbkVhOXVWVgG/opM1TQ0l6F0+q7F4okiZb1EpEjuixT+pHi+jUZ7Q3OOzcNaG6URcIzRQ==
+"@orbit/jsonapi@0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/jsonapi/-/jsonapi-0.17.0-beta.25.tgz#1d59b000a677e5e0078941f59799cdd1db489547"
+  integrity sha512-Z+EInf+D+Es1Wu+tdRJVCbN/48Zkl8tzKnvQ59c6mKSbdLkULG8rE63wDULGCHq63RIBUugZ03OoPFf2Iagujw==
   dependencies:
-    "@orbit/core" "^0.17.0-beta.14"
-    "@orbit/data" "^0.17.0-beta.14"
-    "@orbit/records" "^0.17.0-beta.14"
-    "@orbit/serializers" "^0.17.0-beta.14"
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/core" "^0.17.0-beta.25"
+    "@orbit/data" "^0.17.0-beta.25"
+    "@orbit/records" "^0.17.0-beta.25"
+    "@orbit/serializers" "^0.17.0-beta.25"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/memory@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/memory/-/memory-0.17.0-beta.14.tgz#c35bcfbeac3e4cf44d612d58cae2c5c786e6f079"
-  integrity sha512-VtpTrB48X/iqgF//pZeKvCxQ5tT98KR3yP3K+jzwEr7yN1fJjyKwgjviFQ93ZR1M1nT629Ga50982S/IKaEZJQ==
+"@orbit/memory@0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/memory/-/memory-0.17.0-beta.25.tgz#4e74c95ecec120409d6e94bd239b246ba02f3ef2"
+  integrity sha512-nQOhsaysth/J6iZT9eDMkCz/0Q4xlyiAGEeKoRvhaK2pfhSx+9AtZaHTlVVijMGB7U+osJKnnf/bpzTpI1+Whg==
   dependencies:
-    "@orbit/core" "^0.17.0-beta.14"
-    "@orbit/data" "^0.17.0-beta.14"
-    "@orbit/immutable" "^0.17.0-beta.14"
-    "@orbit/record-cache" "^0.17.0-beta.14"
-    "@orbit/records" "^0.17.0-beta.14"
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/core" "^0.17.0-beta.25"
+    "@orbit/data" "^0.17.0-beta.25"
+    "@orbit/immutable" "^0.17.0-beta.25"
+    "@orbit/record-cache" "^0.17.0-beta.25"
+    "@orbit/records" "^0.17.0-beta.25"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/record-cache@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/record-cache/-/record-cache-0.17.0-beta.14.tgz#91884ae49f3d11b54db8a4dc4e5a853313fb05f9"
-  integrity sha512-ygBtm25+ayrsN0sUjwUUhevHaW30g6H9JBrU8lo4Tu0v1Id5NVxsikPTtFCXiZBDQM1QxH1XpV6DLDLPIjH6bQ==
+"@orbit/record-cache@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/record-cache/-/record-cache-0.17.0-beta.25.tgz#cf4211446f588aa55980f441f9a056c1614c5e25"
+  integrity sha512-qoRdwT+EGjX46fVZZSURRBreLwJq8IkF7tiMC16WiZOGWVR76YjnBn0ugRNzYmUTVMc2648EJzkEqzH1glLocA==
   dependencies:
-    "@orbit/core" "^0.17.0-beta.14"
-    "@orbit/data" "^0.17.0-beta.14"
-    "@orbit/records" "^0.17.0-beta.14"
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/core" "^0.17.0-beta.25"
+    "@orbit/data" "^0.17.0-beta.25"
+    "@orbit/records" "^0.17.0-beta.25"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/records@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/records/-/records-0.17.0-beta.14.tgz#c38b915fbf1dc5b1f7f968452a7898a4e7f7e240"
-  integrity sha512-Em40SoLdIxwM3wlwz3pif7zfBzFS+HSe1iRqGoQw0kAq3Qlp53bRU4svUT0pIyd/psQnr1FcQJ2ONjYjyll8SQ==
+"@orbit/records@0.17.0-beta.25", "@orbit/records@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/records/-/records-0.17.0-beta.25.tgz#46d41b688499d959422926ee0c66ec7e515e0938"
+  integrity sha512-Eg9YzvOuWnbNeK69WvSw3huoTFt+7DkDuwsTBeTi4bLjyo+NHbOHmZPHwS7U+VsXjAUtMWA0LCGRKdU836UjDg==
   dependencies:
-    "@orbit/data" "^0.17.0-beta.14"
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/data" "^0.17.0-beta.25"
+    "@orbit/utils" "^0.17.0-beta.25"
+    "@orbit/validators" "^0.17.0-beta.25"
 
-"@orbit/serializers@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/serializers/-/serializers-0.17.0-beta.14.tgz#07a99cdffd1c73762d03de8304539414ecfcb075"
-  integrity sha512-xOo3vG8oSNZKasK+qvZhX1EHoaVF8EmUEbVx/rE+TnzLSjBPbqtk4+MoUDEMhLHRreCWX2CPsm3Maz0PLTM7QQ==
+"@orbit/serializers@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/serializers/-/serializers-0.17.0-beta.25.tgz#ca26c8b4e18c244db780477e0c21164afe12a211"
+  integrity sha512-JfrTFqWoaivyRIj9bcq7lHbEnhF3t4PoouplFDbvmvE9AEclnbiQ7J+/Tsr4Xzyk8LCBTNBr50HVvZFgpJRH5g==
   dependencies:
-    "@orbit/utils" "^0.17.0-beta.14"
+    "@orbit/utils" "^0.17.0-beta.25"
 
-"@orbit/utils@^0.17.0-beta.14":
-  version "0.17.0-beta.14"
-  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.17.0-beta.14.tgz#b9b8dec255cee355e82b21e754e8e2c3bb1e2287"
-  integrity sha512-1eGvrGKJjXtgBWJ2nQe83nkIk6Kv4QvataoPoc+waRjLdoBIAgIpX7XnVTJ3XMCQO0yDxHQ7wOTpfvtnYwma0A==
+"@orbit/utils@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.17.0-beta.25.tgz#95c34c58f732a42addbcb7271213896cb3b29a25"
+  integrity sha512-7YdfdHlQr+838ikOlu053/dG+8wrn5Ddw/E/7+YCT3UuNtonWy69e3omZkuFsHEf+6zNDV8FouxfOS9txCXFcg==
+
+"@orbit/validators@^0.17.0-beta.25":
+  version "0.17.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@orbit/validators/-/validators-0.17.0-beta.25.tgz#54a7d8a591e6128ba3a13e7cf44f5907ea6986b4"
+  integrity sha512-eB0OIC8gIoeoBDgjKRqW9nji+SNgGA0sD0fr0lQuGmmWmTax4+GQuciXhibiWuh4sBxzQzxfNMrCfOos4h2MSw==
+  dependencies:
+    "@orbit/utils" "^0.17.0-beta.25"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -3316,12 +3324,11 @@ ora@5.3.0:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-orbit-sql@^0.4.2:
+"orbit-sql@https://github.com/backspace/orbit-sql.git#orbit-0.17.0-beta.25-no-legacy-test":
   version "0.4.2"
-  resolved "https://registry.yarnpkg.com/orbit-sql/-/orbit-sql-0.4.2.tgz#4aca0cb7ca75c1f6e6148743af8651b19bbccac4"
-  integrity sha512-SnoojwkoKjRYCP8Dlqt/Y3ZObDvFVOG6meDTBECYBbBJQjeeYfVKt+9nCkqIyGS+jCs3nyeoHo4XDqgigTN4/A==
+  resolved "https://github.com/backspace/orbit-sql.git#e0f7e1216adf4b34a9278931f605406fc8e1dbbf"
   dependencies:
-    "@orbit/records" "^0.17.0-beta.14"
+    "@orbit/records" "0.17.0-beta.25"
     inflected "^2.1.0"
     knex "^0.21.18"
     objection "^2.2.14"


### PR DESCRIPTION
This is a followup to [this PR](https://github.com/tchak/orbit-sql/pull/8). I needed to use the code from that branch (and with the not-building test removed).

This seems pretty straightforward; `UnknownSerializer` is no longer needed because [`Serializer` can be used directly](https://github.com/orbitjs/orbit/pull/837). I chose to rename the two deserialising functions to remove the QB that was also removed from the imported class names.

(How can I get the tests to run? 🤔 They pass locally)